### PR TITLE
Removed extra move from Controller

### DIFF
--- a/js/Controller.js
+++ b/js/Controller.js
@@ -46,9 +46,6 @@ class Controller{
             this.mapmodel.setVisible(this.charmodel.x, this.charmodel.y)
         }
 
-
-        this.charmodel.move(tile.xLoc, tile.yLoc, 1);	// 1 == "1 energy, as a placeholder"
-
         // Handle the win and lose conditions
         if (this.charmodel.x == this.mapmodel.royalDiamondsX && 
         	this.charmodel.y == this.mapmodel.royalDiamondsY){


### PR DESCRIPTION
We were moving the character to the same place twice, which was
depleting our energy twice as fast.

Signed-off-by: David Post <post@pdx.edu>