### PR TITLE
Display items

### DIFF
--- a/js/FrupalModel.js
+++ b/js/FrupalModel.js
@@ -5,7 +5,20 @@ class FrupalModel{
         this.charModel = new CharModel;
         if( obj === undefined )
             return;
-        this.mapmodel.mapHash = obj.mapmodel.mapHash;
+        // Handle Map hash specially
+        var mapHash = Object();
+        var objHash = obj.mapmodel.mapHash;
+        for( var key in objHash ){
+            var tile = new Tile(objHash[key].xLoc,
+                                objHash[key].yLoc,
+                                objHash[key].Visited,
+                                objHash[key].Terrain,
+                                objHash[key].Item);
+
+
+            mapHash[key] = tile;
+        }
+        this.mapmodel.mapHash = mapHash;
         this.mapmodel.name = obj.mapmodel.name;
         this.mapmodel.mapSize = obj.mapmodel.mapSize;
         this.mapmodel._mapSize = obj.mapmodel.mapSize;

--- a/js/MapView.js
+++ b/js/MapView.js
@@ -32,7 +32,7 @@ class MapView{
         if( this.charX === -1)
             return;
         var charCell = document.getElementById(this.charX+','+this.charY);
-        charCell.innerHTML = charCell.innerHTML + "@";
+        charCell.innerHTML = charCell.innerHTML + "|@";
     }
 
     redraw(){
@@ -73,6 +73,47 @@ class MapView{
                         cell.className = "unknown";
                         break;
                 }
+
+                //display items on the map
+                if (tileHash[key].Item != 'None' && tileHash[key].Item != '') {
+                    cell.innerHTML += "|" + tileHash[key].Item;
+                }
+
+                /*
+                if (tileHash[key].Item == 'Axe') {
+                    cell.innerHTML += "|" + 'A';
+                }
+                else if(tileHash[key].Item == 'Treasure Chest') {
+                    cell.innerHTML += "|" + 'TC';
+                }
+                else if(tileHash[key].Item == 'Clue') {
+                    cell.innerHTML += "|" + 'C';
+                }
+                else if(tileHash[key].Item == 'Hatchet') {
+                    cell.innerHTML += "|" + 'H';
+                }
+                else if(tileHash[key].Item == 'Chainsaw') {
+                    cell.innerHTML += "|" + 'CS';
+                }
+                else if(tileHash[key].Item == 'Chisel') {
+                    cell.innerHTML += "|" + 'Ch';
+                }
+                else if(tileHash[key].Item == 'Sledge') {
+                    cell.innerHTML += "|" + 'S';
+                }
+                else if(tileHash[key].Item == 'Jackhammer') {
+                    cell.innerHTML += "|" + 'JH';
+                }
+                else if(tileHash[key].Item == 'Machete') {
+                    cell.innerHTML += "|" + 'M';
+                }
+                else if(tileHash[key].Item == 'Shears') {
+                    cell.innerHTML += "|" + 'Sh';
+                }
+                else if(tileHash[key].Item == 'Binoculars') {
+                    cell.innerHTML += "|" + 'B';
+                }
+                */
             }
 
         }

--- a/js/MapView.js
+++ b/js/MapView.js
@@ -37,7 +37,7 @@ class MapView{
 
     redraw(){
         // Take in the models hashtable
-        var tileHash = this.model.mapHash
+        var tileHash = this.model.mapHash;
         for ( var key in tileHash ){
             // Set the corresponding tile to what it is
             var cell = document.getElementById(key);
@@ -75,45 +75,9 @@ class MapView{
                 }
 
                 //display items on the map
-                if (tileHash[key].Item != 'None' && tileHash[key].Item != '') {
-                    cell.innerHTML += "|" + tileHash[key].Item;
+                if (tileHash[key].Item !== "None" && tileHash[key].Item !== "") {
+                    cell.innerHTML = cell.innerHTML + "|" + tileHash[key].Item;
                 }
-
-                /*
-                if (tileHash[key].Item == 'Axe') {
-                    cell.innerHTML += "|" + 'A';
-                }
-                else if(tileHash[key].Item == 'Treasure Chest') {
-                    cell.innerHTML += "|" + 'TC';
-                }
-                else if(tileHash[key].Item == 'Clue') {
-                    cell.innerHTML += "|" + 'C';
-                }
-                else if(tileHash[key].Item == 'Hatchet') {
-                    cell.innerHTML += "|" + 'H';
-                }
-                else if(tileHash[key].Item == 'Chainsaw') {
-                    cell.innerHTML += "|" + 'CS';
-                }
-                else if(tileHash[key].Item == 'Chisel') {
-                    cell.innerHTML += "|" + 'Ch';
-                }
-                else if(tileHash[key].Item == 'Sledge') {
-                    cell.innerHTML += "|" + 'S';
-                }
-                else if(tileHash[key].Item == 'Jackhammer') {
-                    cell.innerHTML += "|" + 'JH';
-                }
-                else if(tileHash[key].Item == 'Machete') {
-                    cell.innerHTML += "|" + 'M';
-                }
-                else if(tileHash[key].Item == 'Shears') {
-                    cell.innerHTML += "|" + 'Sh';
-                }
-                else if(tileHash[key].Item == 'Binoculars') {
-                    cell.innerHTML += "|" + 'B';
-                }
-                */
             }
 
         }

--- a/js/Tile.js
+++ b/js/Tile.js
@@ -1,42 +1,11 @@
 class Tile {
-    constructor(X, Y, Ter, Visit, item){
+
+    constructor(X, Y, Visit, Ter, item){
         this.Terrain = Ter;
         this.xLoc = X;
         this.yLoc = Y;
         this.Visited = Visit;
         this.Item = item;
-    }
-//GETTERS
-    get Terrain(){
-        return this._Terrain;
-    }
-    get xLoc(){
-        return this._X;
-    }
-    get yLoc(){
-        return this._Y;
-    }
-    get Visited(){
-        return this._Visited;
-    }
-    get Item(){
-        return this._Item;
-    }
-//SETTERS
-    set Terrain(Ter){
-        this._Terrain = Ter;
-    }
-    set xLoc(num){
-        this._X = num;
-    }
-    set yLoc(num){
-        this._Y = num;
-    }
-    set Visited(bool){
-        this._Visited = bool;
-    }
-    set Item(item){
-        this._Item = item;
     }
 }
 

--- a/js/mapModel.js
+++ b/js/mapModel.js
@@ -15,15 +15,15 @@ class mapModel{
         this.royalDiamondsY = 2;
     }
 
-    addTile(X, Y, Ter, Visit, Item){
+    addTile(X, Y, Visit, Ter, Item){
        if(this.mapHash[X+','+Y] === undefined) {
-            this.mapHash[X + ',' + Y] = new Tile(X, Y, Ter, Visit, Item);
+            this.mapHash[X + ',' + Y] = new Tile(X, Y, Visit, Ter, Item);
         }else{
-            this.modTile(X, Y, Ter, Visit, Item);
+            this.modTile(X, Y, Visit, Ter, Item);
         }
     }
 
-    modTile(X, Y, Ter, Visit, Item){
+    modTile(X, Y, Visit, Ter, Item){
         this.mapHash[X+','+Y].xLoc = X;
         this.mapHash[X+','+Y].yLoc = Y;
         this.mapHash[X+','+Y].Terrain = Ter;
@@ -39,119 +39,95 @@ class mapModel{
     }
 
     initTileMeadow(x, y){
-        this.addTile(x, y, Meadow, 1, '');
+        this.addTile(x, y, 0, Meadow, '');
     }
     setVisible(heroX, heroY){
         this.getTile(heroX, heroY).Visited = 1; // 1 is visible
         //REVEALS TILE TO THE RIGHT
         if(heroX + 1 < this.mapSize){
-            this.initTileMeadow(heroX + 1, heroY);
-            this.mapHash[(heroX + 1)+','+heroY].Visited = 1;
+            this.getTile(heroX + 1, heroY).Visited = 1;
             //WRAPS RIGHT TILE IF HERO IS ON FAR RIGHT EDGE OF MAP
         }else if(heroX + 1 >= this.mapSize){
-            this.initTileMeadow(0, heroY);
-            this.mapHash[0+','+heroY].Visited = 1;
+            this.getTile(0, heroY);
         }
         //REVEALS TILE TO LEFT OF HERO
         if(heroX - 1 >= 0){
-            this.initTileMeadow(heroX - 1, heroY);
-            this.mapHash[(heroX - 1)+','+heroY].Visited = 1;
+            this.getTile(heroX - 1, heroY).Visited = 1;
             //WRAPS LEFT TILE IF HERO IS ON FAR LEFT EDGE OF MAP
         }else if(heroX -1 < 0){
-            this.initTileMeadow(this.mapSize - 1, heroY);
-            this.mapHash[(this.mapSize -1)+','+heroY].Visited = 1;
+            this.getTile(this.mapSize - 1, heroY).Visited = 1;
         }
         //REVEALS TILE ABOVE HERO
         if(heroY + 1 < this.mapSize){
-            this.initTileMeadow(heroX, heroY + 1);
-            this.mapHash[heroX+','+(heroY + 1)].Visited = 1;
+            this.getTile(heroX, heroY + 1).Visited = 1;
             //WRAPS TILE ABOVE HERO TO THE BOTTOM IF HERO IS ON TOP EDGE OF MAP
         }else if(heroY + 1 >= this.mapSize){
-            this.initTileMeadow(heroX, 0);
-            this.mapHash[heroX+','+0].Visited = 1;
+            this.getTile(heroX, 0).Visited = 1;
         }
         //REVEALS TILE BELOW HERO
         if(heroY - 1 >= 0){
-            this.initTileMeadow(heroX, heroY - 1);
-            this.mapHash[heroX+','+(heroY - 1)].Visited = 1;
+            this.getTile(heroX, heroY - 1).Visited = 1;
             //WRAPS TILE BELOW HERO TO THE TOP IF THE HERO IS ON THE BOTTOM EDGE OF THE MAP
         }else if(heroY - 1 < 0){
-            this.initTileMeadow(heroX, this.mapSize -1);
-            this.mapHash[heroX+','+(this.mapSize -1)].Visited = 1;
+            this.getTile(heroX, this.mapSize -1).Visited = 1;
         }
         //REVEALS TILE TO THE TOP RIGHT OF HERO
         if(heroX + 1 < this.mapSize && heroY + 1 < this.mapSize){
-            this.initTileMeadow(heroX + 1, heroY + 1);
-            this.mapHash[(heroX + 1)+','+(heroY + 1)].Visited = 1;
+            this.getTile(heroX + 1, heroY + 1).Visited = 1;
             //REVEALS 0,0 IF HERO IS IN TOP RIGHT CORNER OF MAP
         }else if(heroX + 1 >= this.mapSize && heroY + 1 >= this.mapSize){
-            this.initTileMeadow(0 ,0);
-            this.mapHash[0+','+0].Visited = 1;
+            this.getTile(0 ,0).Visited = 1;
             //WRAPS TILE TO BOTTOM
         }else if(heroX + 1 < this.mapSize && heroY + 1 >= this.mapSize){
-            this.initTileMeadow(heroX + 1, 0);
-            this.mapHash[(heroX + 1) + ',' + 0].Visited = 1;
+            this.getTile(heroX + 1, 0).Visited = 1;
             //WRAPS TILE TO OTHER SIDE
         }else if(heroX + 1 >= this.mapSize && heroY + 1 < this.mapSize){
-            this.initTileMeadow(0, heroY +1);
-            this.mapHash[0+','+(heroY +1)].Visited = 1;
+            this.getTile(0, heroY +1).Visited = 1;
         }
 
         //REVEALS TILE TO THE TOP LEFT OF HERO
         if(heroX - 1 >= 0 && heroY + 1 < this.mapSize){
-            this.initTileMeadow(heroX - 1, heroY + 1);
-            this.mapHash[(heroX - 1)+','+(heroY + 1)].Visited = 1;
+            this.getTile(heroX - 1, heroY + 1).Visited = 1;
             //REVEALS mapSize - 1, 0 IF HERO IS IN TOP LEFT CORNER
         }else if(heroX - 1 < 0 && heroY + 1 >= this.mapSize){
-            this.initTileMeadow(this.mapSize -1, 0);
-            this.mapHash[(this.mapSize -1)+','+0].Visited = 1;
+            this.getTile(this.mapSize -1, 0).Visited = 1;
             //WRAPS TILE TO BOTTOM
         }else if(heroX - 1 > 0 && heroY + 1 >= this.mapSize){
-            this.initTileMeadow(heroX - 1, 0);
-            this.mapHash[(heroX -1)+','+ 0].Visited = 1;
+            this.getTile(heroX - 1, 0).Visited = 1;
             //WRAPS TILE TO OTHER SIDE
         }else if(heroX -1 < 0 && heroY + 1 < this.mapSize){
-            this.initTileMeadow(this.mapSize -1, heroY + 1);
-            this.mapHash[(this.mapSize -1)+','+(heroY + 1)].Visited = 1;
+            this.getTile(this.mapSize -1, heroY + 1).Visited = 1;
         }
 
 
         //REVEALS TILE TO BOTTOM RIGHT OF HERO
         if(heroX + 1 < this.mapSize && heroY - 1 >= 0){
-            this.initTileMeadow(heroX + 1, heroY - 1);
-            this.mapHash[(heroX + 1)+','+(heroY - 1)].Visited = 1;
+            this.getTile(heroX + 1, heroY - 1).Visited = 1;
             //REVEALS 0,mapSize -1 IF THE HERO IS IN THE BOTTOM RIGHT CORNER
         }else if(heroX + 1 >= this.mapSize && heroY - 1 < 0){
-            this.initTileMeadow(0, this.mapSize -1);
-            this.mapHash[0+','+(this.mapSize - 1)].Visited = 1;
+            this.getTile(0, this.mapSize -1).Visited = 1;
             //WRAPS TILE TO TOP
         }else if(heroX + 1 < this.mapSize && heroY - 1 < 0){
-            this.initTileMeadow(heroX + 1, this.mapSize -1);
-            this.mapHash[(heroX + 1)+','+(this.mapSize -1)].Visited = 1;
+            this.getTile(heroX + 1, this.mapSize -1).Visited = 1;
             //WRAPS TILE TO OTHER SIDE
         }else if(heroX + 1 >= this.mapSize && heroY - 1 >= 0){
-            this.initTileMeadow(0 , heroY -1);
-            this.mapHash[0+','+(heroY -1)].Visited = 1;
+            this.getTile(0 , heroY -1).Visited = 1;
         }
 
 
 
         //REVEALS TILE TO BOTTOM LEFT OF HERO
         if(heroX -1 >= 0 && heroY - 1 >= 0){
-            this.initTileMeadow(heroX - 1, heroY - 1);
-            this.mapHash[(heroX - 1)+','+(heroY - 1)].Visited = 1;
+            this.getTile(heroX - 1, heroY - 1).Visited = 1;
             //REVEALS TOP RIGHT CORNER IF HERO IS IN BOTTOM LEFT CORNER
         }else if(heroX -1 < 0 && heroY - 1 < 0){
-            this.initTileMeadow(this.mapSize - 1, this.mapSize - 1);
-            this.mapHash[(this.mapSize -1)+','+(this.mapSize-1)].Visited = 1;
+            this.getTile(this.mapSize - 1, this.mapSize - 1).Visited = 1;
             //WRAPS TILE TO TOP
         }else if(heroX - 1 > 0 && heroY - 1 < 0){
-            this.initTileMeadow(heroX - 1, this.mapSize -1);
-            this.mapHash[(heroX - 1)+','+(this.mapSize - 1)].Visited = 1;
+            this.getTile(heroX - 1, this.mapSize -1).Visited = 1;
             //WRAPS TILE TO OTHER SIDE
         }else if(heroX - 1 < 0 && heroY - 1 >= 0){
-            this.initTileMeadow(this.mapSize -1, heroY -1);
-            this.mapHash[(this.mapSize - 1)+','+(heroY -1)].Visited = 1;
+            this.getTile(this.mapSize -1, heroY -1).Visited = 1;
         }
     }
     //Should handle wrapping around the world.  X,Y being passed in should be the charModel location at the time
@@ -189,13 +165,6 @@ class mapModel{
                 x = 0;
             }
         }
-
-
-        var tile =  this.mapHash[x+','+y];
-        if( tile == null ) {
-            this.initTileMeadow(x, y);
-            tile = this.mapHash[x+','+y];
-     }
-     return tile;
+     return this.getTile(x,y);
     }
 }


### PR DESCRIPTION
After the load_maps update more issues were realized with the loading due to this patch revealing items. I worked out those issues now which included some work on simplifying some of the code in mapModel.js while resolving issues that were confusing. Read the commit message for more information.

Included in this was changing the order of Tile's constructor to be inline with the Map File format which makes the parser much easier for loadMap.py. This then forced changes to other functions to bring them all in line so it wouldn't be confusing which each piece of code using a different order.

One other thing which may be noticed is the removal of explicit setters and getters. I'm not quite understanding why, but there were issues caused with having them when they did nothing other than set and get. Again, this was for the loadMap.py and loading from JSON.

Please test this by first going to `maps/Sample_Frupal.html` and then `mapview_test.html`. After going to the Sample_Frupal once this should be persistent. Other maps can be made with the tools and played with.

The sample map includes tiles with forest and water, though technically it is a corrupted file with no Diamond.