### PR TITLE
Added more Royal Diamonds code (good enough for Sprint 1)

### DIFF
--- a/js/mapModel.js
+++ b/js/mapModel.js
@@ -10,9 +10,9 @@ class mapModel{
         // like another item. The map file Warren supplied doesn't include royal 
         // diamonds, but the requirements also say that a map is corrupt if it doesn't
         // include diamonds. Anyway, for now, I'm just placing them as a special, 
-        // item-like thing at (3,2).
-        this.royalDiamondsX = 3;
-        this.royalDiamondsY = 2;
+        // item-like thing.
+        this.royalDiamondsX = -1;
+        this.royalDiamondsY = -1;
     }
 
     addTile(X, Y, Visit, Ter, Item){
@@ -20,6 +20,12 @@ class mapModel{
             this.mapHash[X + ',' + Y] = new Tile(X, Y, Visit, Ter, Item);
         }else{
             this.modTile(X, Y, Visit, Ter, Item);
+        }
+
+        if (Item === "Royal Diamonds"){
+            // This Tile contains the Diamonds, so record these special coordinates
+            this.royalDiamondsX = X;
+            this.royalDiamondsY = Y;
         }
     }
 

--- a/maps/Sample_Frugal.html
+++ b/maps/Sample_Frugal.html
@@ -17,8 +17,7 @@
         model.mapmodel.addTile(12,12,1,1,'None');
         model.mapmodel.addTile(13,12,0,1,'Tree');
         model.mapmodel.addTile(14,12,0,2,'None');
-        // Two square North from the starting location are the Royal Diamonds
-        model.mapmodel.addTile(12,13,0,0,'None');
+        model.mapmodel.addTile(12,13,0,1,'None');
         model.mapmodel.addTile(12,14,0,0,'Royal Diamonds');
         localStorage.clear();
         localStorage.setItem('map', JSON.stringify(model));

--- a/maps/Sample_Frugal.html
+++ b/maps/Sample_Frugal.html
@@ -17,6 +17,9 @@
         model.mapmodel.addTile(12,12,1,1,'None');
         model.mapmodel.addTile(13,12,0,1,'Tree');
         model.mapmodel.addTile(14,12,0,2,'None');
+        // Two square North from the starting location are the Royal Diamonds
+        model.mapmodel.addTile(12,13,0,0,'None');
+        model.mapmodel.addTile(12,14,0,0,'Royal Diamonds');
         localStorage.clear();
         localStorage.setItem('map', JSON.stringify(model));
     }

--- a/maps/raw/default.map
+++ b/maps/raw/default.map
@@ -12,3 +12,5 @@ Pretty Rock
 12,12,1,1,None
 13,12,0,1,Tree
 14,12,0,2,None
+12,13,0,1,None
+12,14,0,0,Royal Diamonds


### PR DESCRIPTION
More work related to those Royal Diamonds. I tested this using
mapview_test.html.

I added Royal Diamonds to the map that's built by Sample_Frupal.html.
So, to test this, start by sending your browser to maps/Sample_Frupal.
The diamonds are now 2 squares North of the starting position at 12, 14.
There's code in mapModel that stores the coordinates of the special
Royal Diamonds square when we're loading the map. By adding this code,
we're adding a way for maps to specify the Royal Diamonds' location;
before, there was a very crude way of specifying that location by
hard-coding it in the JS code instead of the map.

In the longer term, we should redo this after we implement the inventory
and items features. These Royal Diamonds are currently the one-and-only
special item in the game, but they ought to integrate with the other
items later (maybe in Sprint 2)

Signed-off-by: DanielBrewerPsu <brewer9@pdx.edu>