### PR TITLE
Fix error about message div

### DIFF
--- a/gameView.html
+++ b/gameView.html
@@ -2,6 +2,7 @@
 <title> A-Team Frupal </title>
 <html>
 <head>
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link type="text/css" rel="stylesheet" href="style.css"/>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js" charset="utf-8"></script>

--- a/gameView.html
+++ b/gameView.html
@@ -99,12 +99,8 @@
                 </div>
             </form>
         </div>
-
-        <script>
-            controller.initGame();
-        </script>
-
     </div>
+
     <div class="messages">
         <h2>Messages to Read</h2>
         <div id="message"></div>
@@ -113,6 +109,10 @@
             consectetur laborum biltong, irure chuck ad quis officia salami buffalo. Minim turkey sirloin cow shoulder
             doner.</p>
     </div>
+
+    <script>
+        controller.initGame();
+    </script>
 </div>
 </body>
 </html>


### PR DESCRIPTION
I think this was happening because controller.initGame, which calls
MessageView.redraw, appeared above the definition on the "message" div
in the html file. The Firefox browser does read this file top to bottom,
so "message" has not been define at the time that initGame was called.
I fixed this by moving controller.initGame in the file. Another approach
to this category of bug is to use onload and ensure that the whole file
is loaded before doing controller.initGame.

Signed-off-by: DanielBrewerPsu <brewer9@pdx.edu>