### PR TITLE
Fixes visibility issue on wrapping

### DIFF
--- a/js/mapModel.js
+++ b/js/mapModel.js
@@ -54,7 +54,7 @@ class mapModel{
             this.getTile(heroX + 1, heroY).Visited = 1;
             //WRAPS RIGHT TILE IF HERO IS ON FAR RIGHT EDGE OF MAP
         }else if(heroX + 1 >= this.mapSize){
-            this.getTile(0, heroY);
+            this.getTile(0, heroY).Visited = 1;
         }
         //REVEALS TILE TO LEFT OF HERO
         if(heroX - 1 >= 0){


### PR DESCRIPTION
One of the conditions was set incorrectly when you wrapped around the map,
the tile directly in front would not show.

Signed-off-by WEI <562524945@qq.com>