### PR TITLE
Improved detection for "corrupt" maps with tiles outside of the map

### DIFF
--- a/maps/raw/cellTooHigh.map
+++ b/maps/raw/cellTooHigh.map
@@ -1,0 +1,17 @@
+A map with a cell where x=26, one too low for the map
+25
+######################
+12,12
+103
+1000
+Axe
+Axe
+Shears
+Pretty Rock
+######################
+12,12,1,1,None
+13,12,0,1,Tree
+14,12,0,2,None
+12,13,0,1,None
+12,14,0,0,Royal Diamonds
+26,14,0,0,None

--- a/maps/raw/cellTooLow.map
+++ b/maps/raw/cellTooLow.map
@@ -1,0 +1,17 @@
+A map with a cell where x=-1, one too low for the map
+25
+######################
+12,12
+103
+1000
+Axe
+Axe
+Shears
+Pretty Rock
+######################
+12,12,1,1,None
+13,12,0,1,Tree
+14,12,0,2,None
+12,13,0,1,None
+12,14,0,0,Royal Diamonds
+-1,14,0,0,None

--- a/tools/loadMap.py
+++ b/tools/loadMap.py
@@ -56,7 +56,7 @@ def loadMap( line ):
 def chkMap( line, mSize ):
     # Store map lines
     l = line.split(",")
-    if(int(l[0]) > mSize or int(l[1]) > mSize):
+    if(int(l[0]) >= mSize or int(l[0]) < 0 or int(l[1]) >= mSize or int(l[1]) < 0):
         return True;		
     return False;
 	


### PR DESCRIPTION
 - Added a test map, cellTooLow.map with tiles with a negative
coordinate.
 - Added a test map, cellTooHigh.map with a tile >= mapSize
 - Fixed bug in loadMap.py where detection for >= mapSize was off by
one.

Signed-off-by: DanielBrewerPsu <brewer9@pdx.edu>