### PR TITLE
Fixed arrow key support in Chrome

### DIFF
--- a/gameView.html
+++ b/gameView.html
@@ -58,14 +58,14 @@
         }
 
         // Install keyboard handler for arrow keys
-        $(window).keypress(function(event) {
-            if (event.key === "ArrowUp" || event.key === 'w' || event.key === ',') {
+        $(window).keydown(function(event) {
+            if (event.keyCode === 38 || event.key === 'w' || event.key === ',') {	//"ArrowUp"
                 north();
-            } else if (event.key === "ArrowRight" || event.key === 'd' || event.key === 'e') {
+            } else if (event.keyCode === 39 || event.key === 'd' || event.key === 'e') {
                 east();
-            } else if (event.key === "ArrowDown" || event.key === 's' || event.key === 'o') {
+            } else if (event.keyCode === 40 || event.key === 's' || event.key === 'o') {
                 south();
-            } else if (event.key === "ArrowLeft" || event.key === 'a' || event.key === 'A') {
+            } else if (event.keyCode === 37 || event.key === 'a' || event.key === 'A') {
                 west();
             }
         })


### PR DESCRIPTION
Fixes #47 

The old code worked in Firefox and allegedly Opera. This code uses onkeydown
instead of onkeypress and "keyCodes" instead of "key" values, so it has
different compatibility. It's working on Firefox and Chrome on Windows for me.

Signed-off-by: DanielBrewerPsu <brewer9@pdx.edu>