### PR TITLE
Changed visRange to be default 1

### DIFF
--- a/js/CharModel.js
+++ b/js/CharModel.js
@@ -1,5 +1,5 @@
 class CharModel{
-    constructor(X,Y, Energy, Whiffles, visRange){
+    constructor(X,Y, Energy, Whiffles){
         this.x = X;
         this.y = Y;
         this.energy = Energy;
@@ -8,7 +8,7 @@ class CharModel{
         // hasFoundRoyalDiamonds is a simple flag for now. Later, we might replace it 
         // with a getter function that checks the inventory for Royal Diamonds
         this.hasFoundRoyalDiamonds = false;
-        this.visrange = visRange;
+        this.visrange = 1;
     }
     move( X, Y, EnergySpent ){
         this.x = X;

--- a/maps/Sample_Frugal.html
+++ b/maps/Sample_Frugal.html
@@ -9,7 +9,7 @@
         model.mapmodel.name = 'Sample Frupal Game Map';
         model.mapmodel.mapSize = 25;
 
-        model.charModel = new CharModel(12,12, 103, 1000, 1);
+        model.charModel = new CharModel(12,12, 103, 1000);
         model.charModel.inventory.push('Axe');
         model.charModel.inventory.push('Axe');
         model.charModel.inventory.push('Shears');


### PR DESCRIPTION
Set this as a default 1 instead of loading it from the constructor. The loadmap
script would have needed updating, along with all maps in use, in order to add
something to the constructor. Seeing how the constructor is only really used for
loadMap.py, and there is a simple default, we are setting it in the constructor.

Signed-off-by: David Post <post@pdx.edu>