### PR TITLE
Added binoculars to Labrynth map

### DIFF
--- a/maps/Labrynth.html
+++ b/maps/Labrynth.html
@@ -45,6 +45,7 @@
         model.mapmodel.addTile(18,18,0,2,'None');
         model.mapmodel.addTile(19,19,0,2,'None');
         model.mapmodel.addTile(20,20,0,2,'None');
+        model.mapmodel.addTile(21,20,0,1,'Binoculars');
         model.mapmodel.addTile(21,21,0,2,'None');
         model.mapmodel.addTile(22,22,0,2,'None');
         model.mapmodel.addTile(23,23,0,2,'None');

--- a/maps/raw/Labrynth.map
+++ b/maps/raw/Labrynth.map
@@ -37,6 +37,7 @@ Pretty Rock
 18,18,0,2,None
 19,19,0,2,None
 20,20,0,2,None
+21,20,0,1,Binoculars
 21,21,0,2,None
 22,22,0,2,None
 23,23,0,2,None


### PR DESCRIPTION
Binoculars had only been in some test maps. I want to see them in the
main Labrynth map file so we can test "pick up items" and the visibility
code in the main branch.

Signed-off-by: DanielBrewerPsu <brewer9@pdx.edu>