### PR TITLE
Added a Value number for Royal Diamonds

### DIFF
--- a/js/CharModel.js
+++ b/js/CharModel.js
@@ -39,5 +39,6 @@ let itemTypeToPriceMap = {
     "Pretty Rock": 1,
     "Shears": 20,
     "Binoculars": 50,
-    "Power Bar": 20
+    "Power Bar": 20,
+    "Royal Diamonds": "999,999+"
 };


### PR DESCRIPTION
This fixes a recently introduced issue: When the player picks up the
royal diamonds, their value is listed as "undefined". Now, they are
listed as this colorful "999,999+" number. In testing, that value seems
to work elsewhere, because there's no code elsewhere that depends on
those values being numeric (like in a purchasing system).

Oi, so much explanation for a 1 line fix :(

Signed-off-by: DanielBrewerPsu <brewer9@pdx.edu>